### PR TITLE
fix aliases in add_missing_variables

### DIFF
--- a/oceanspy/compute.py
+++ b/oceanspy/compute.py
@@ -109,6 +109,12 @@ def _add_missing_variables(od, varList, FUNC2VARS=_FUNC2VARS):
     _check_instance({'od': od}, ' oceanspy.OceanDataset')
     varList = _check_list_of_string(varList, 'varList')
 
+    # Don't use aliased names
+    if od.aliases:
+        varList = [od._aliases_flipped[var]
+                   if var in od._aliases_flipped else var
+                   for var in varList]
+
     # Return here if all variables already exist
     varList = [var
                for var in varList

--- a/oceanspy/compute.py
+++ b/oceanspy/compute.py
@@ -32,7 +32,8 @@ from collections import OrderedDict as _OrderedDict
 # From OceanSpy (private)
 from . import utils as _utils
 from ._ospy_utils import (_check_instance, _check_list_of_string,
-                          _handle_aliased, _check_ijk_components)
+                          _handle_aliased, _check_ijk_components,
+                          _rename_aliased)
 
 # Hard coded  list of variables outputed by functions
 _FUNC2VARS = _OrderedDict(potential_density_anomaly=['Sigma0'],
@@ -109,13 +110,8 @@ def _add_missing_variables(od, varList, FUNC2VARS=_FUNC2VARS):
     _check_instance({'od': od}, ' oceanspy.OceanDataset')
     varList = _check_list_of_string(varList, 'varList')
 
-    # Don't use aliased names
-    if od.aliases:
-        varList = [od._aliases_flipped[var]
-                   if var in od._aliases_flipped else var
-                   for var in varList]
-
     # Return here if all variables already exist
+    varList = _rename_aliased(od, varList)
     varList = [var
                for var in varList
                if var not in od._ds.variables]

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -24,7 +24,7 @@ from . import utils as _utils
 from . import compute as _compute
 from ._ospy_utils import (_check_instance, _check_range,
                           _check_list_of_string, _check_native_grid,
-                          _check_part_position)
+                          _check_part_position, _rename_aliased)
 
 # Recommended dependencies (private)
 try:
@@ -540,6 +540,7 @@ def cutout(od,
     if varList is not None:
         # Make sure it's a list
         varList = list(varList)
+        varList = _rename_aliased(od, varList)
 
         # Compute missing variables
         od = _compute._add_missing_variables(od, varList)


### PR DESCRIPTION
- Close #123 

When aliases are used, we need to point to the OceanSpy reference names in order to compute missing variables. 