### PR TITLE
Update catalog

### DIFF
--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -161,6 +161,72 @@ sources:
         parallel: True
     metadata:
       rename:
+        T: time  
+
+  # ===========================
+  # IGPyearlong
+  grd_IGPyearlong:
+    description: Grid of IGPyearlong
+    driver: netcdf
+    args:
+      urlpath: /home/idies/workspace/ocean_circulation/data01_01/IGP/grid.nc
+      xarray_kwargs:
+        engine: netcdf4
+        drop_variables: ['RC', 'RF', 'RU', 'RL']
+    metadata:
+      manipulate_coords:
+        coordsUVfromG: True
+      grid_coords: 
+        add_midp: True
+        grid_coords:
+          Y:
+            Y: 
+            Yp1: 0.5
+          X:
+            X: 
+            Xp1: 0.5
+          Z:
+           Z: 
+           Zp1: 0.5
+           Zu: 0.5
+           Zl: -0.5
+          time: 
+            time: -0.5
+      shift_averages: 
+        averageList: ['UVELMASS', 'VVELMASS', 'WVELMASS',
+                      'ADVr_TH', 'ADVx_TH', 'ADVy_TH', 'DFrI_TH',
+                      'ADVr_SLT', 'ADVx_SLT', 'ADVy_SLT', 'DFrI_SLT',
+                      'KPPg_TH', 'KPPg_SLT', 'oceSPtnd',
+                      'oceQsw_AVG', 'TFLUX', 'SFLUX', 'oceFWflx_AVG']
+      parameters:
+        rSphere: 6.371e+03
+        eq_state: mdjwf
+        rho0: 1027
+        g: 9.8156
+        eps_nh: 0 
+        omega: 7.292123516990375e-05
+        c_p: 3.986e+03
+        tempFrz0: 9.01e-02
+        dTempFrz_dS: -5.75e-02
+      name: IGPyearlong
+      description: |
+        High-resolution numerical simulation carried out in parallel to the observational
+        component of the Iceland Greenland Seas Project (IGP). Year-long simulation.
+      citation: | 
+        Renfrew et al., 2019 - BAMS.
+      projection: Mercator
+
+  fld_IGPyearlong:
+    description: Fields of IGPyearlong
+    driver: netcdf
+    args:
+      urlpath: /home/idies/workspace/ocean_circulation/data*_*/IGP/day_*.nc
+      xarray_kwargs:
+        engine: netcdf4
+        concat_dim: T
+        parallel: True
+    metadata:
+      rename:
         T: time
 
   # ===========================


### PR DESCRIPTION
We can now release the year-long IGP run.
The netcdf files are distributed on the filedb nodes.
From SciServer, the name of the volume is `Ocean Circulation (filedb)`.

We need to update the documentation, mentioning that both `Ocean Circulation` and `Ocean Circulation (filedb)` need to be selected. I'll do it later today, so for now `IGPyearlong` will not show up in the documentation.
