### PR TITLE
Fix transport for curvilinear grids

### DIFF
--- a/oceanspy/compute.py
+++ b/oceanspy/compute.py
@@ -2080,6 +2080,8 @@ def mooring_volume_transport(od):
     mooring = od._ds["mooring"]
     XC = od._ds["XC"].squeeze(("Y", "X"))
     YC = od._ds["YC"].squeeze(("Y", "X"))
+    Xind = od._ds["Xind"].squeeze(("Y", "X"))
+    Yind = od._ds["Yind"].squeeze(("Y", "X"))
     XU = od._ds["XU"].squeeze(("Y"))
     YU = od._ds["YU"].squeeze(("Y"))
     XV = od._ds["XV"].squeeze(("X"))
@@ -2106,8 +2108,8 @@ def mooring_volume_transport(od):
     V1_dir = _np.zeros((len(YC), 2))
 
     # Steps
-    diffX = _np.diff(XC)
-    diffY = _np.diff(YC)
+    diffX = _np.diff(Xind)
+    diffY = _np.diff(Yind)
 
     # Closed array?
     if XC[0] == XC[-1] and YC[0] == YC[-1]:

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -651,6 +651,12 @@ def mooring_array(od, Ymoor, Xmoor, **kwargs):
         Subsampled oceandataset.
     """
 
+    # Add indexes needed for transports
+    Yind, Xind = _xr.broadcast(od._ds["Y"], od._ds["X"])
+    od._ds["Xind"] = Xind.transpose(*od._ds["XC"].dims)
+    od._ds["Yind"] = Yind.transpose(*od._ds["YC"].dims)
+    od._ds = od._ds.set_coords(["Xind", "Yind"])
+
     # Check
     _check_native_grid(od, "mooring_array")
 


### PR DESCRIPTION
There is a bug in the function that computes transports when using curvilinear grids (the regional setups with rectilinear grids are not affected).
The issue is that currently OceanSpy infers whether path segments are aligned with the X or Y axis using latitude and longitude.
This does not work with curvilinear grids, as the segments might not be zonal/meridional.

The fix is quite straightforward though. We just have to keep track of the indexes (X/Yind variables are now added to the `OceanDataset` by `subsample.mooring_array`). These indexes will then be used by `compute.mooring_volume_transport` to infer the orientation of the segments.

This plot shows the bug:
![image](https://user-images.githubusercontent.com/22245117/101291860-c4a2e800-3803-11eb-9663-909f20861644.png)

This plot shows the fix:
![image](https://user-images.githubusercontent.com/22245117/101291937-3ed36c80-3804-11eb-8ab4-82b4c6e7efeb.png)

Sorry, the plots are not great but if you zoom on `Path 0` you should be able to see what's wrong.