### PR TITLE
fill nans in transport function

### DIFF
--- a/oceanspy/compute.py
+++ b/oceanspy/compute.py
@@ -2096,10 +2096,10 @@ def mooring_volume_transport(od):
     )
 
     # Extract left and right values
-    U1 = U_tran.isel(Xp1=1)
-    U0 = U_tran.isel(Xp1=0)
-    V1 = V_tran.isel(Yp1=1)
-    V0 = V_tran.isel(Yp1=0)
+    U1 = U_tran.isel(Xp1=1).fillna(0)
+    U0 = U_tran.isel(Xp1=0).fillna(0)
+    V1 = V_tran.isel(Yp1=1).fillna(0)
+    V0 = V_tran.isel(Yp1=0).fillna(0)
 
     # Initialize direction
     U0_dir = _np.zeros((len(XC), 2))


### PR DESCRIPTION
Another fix to the transport function.
There are models that return land values masked with nans. We need to fill nans with zeros in the transport function, as we compute the velocity components separately and then we sum (i.e., near land, if u=1 and v=nan, u+v=nan, we want u+v=1)