### PR TITLE
grid coords for ECCO

### DIFF
--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -837,7 +837,7 @@ sources:
         hFacS: HFacS
         hFacW: HFacW
       grid_coords:
-        add_midp: False
+        add_midp: True
         grid_coords:
           Y:
             Y:


### PR DESCRIPTION
Needed to update `grid_coords` for ECCO data to be able to read it properly. 

changed `add_midp=True`.

Just a quick fix. 