### PR TITLE
switch off 3.10 and use micromamba

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,9 @@ jobs:
           environment-name: oceanspy_test
           channels: conda-forge
           cache-env: true
-          cache-env-key: ubuntu-latest-${{ '{{ matrix.python-version }}' }}
+          cache-env-key: ubuntu-latest-${{ matrix.python-version }}
           extra-specs: |
-            python=${{ '{{matrix.python-version }}' }}
+            python=${{ matrix.python-version }}
 
       - name: Set up conda environment
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,17 +19,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9"]
     steps:
       - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/provision-with-micromamba@v12
         with:
           environment-file: ci/environment.yml
-          activate-environment: oceanspy_test
-          auto-update-conda: false
-          python-version: ${{ matrix.python-version }}
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          environment-name: oceanspy_test
+          channels: conda-forge
+          cache-env: true
+          cache-env-key: ubuntu-latest-${{ '{{ matrix.python-version }}' }}
+          extra-specs: |
+            python=${{ '{{matrix.python-version }}' }}
 
       - name: Set up conda environment
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,9 @@ jobs:
     name: Build (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        include:
+        - python-version: '3.9'
     steps:
       - uses: actions/checkout@v3
       

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,7 +9,7 @@ If you would like to use OceanSpy for your own datasets and run it on a local ma
 Required dependencies
 ---------------------
 
-* Python 3.9, 3.10
+* Python 3.9
 * dask_
 * xarray_
 * xgcm_

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
     ],
     description=(
         "OceanSpy: A Python package to"


### PR DESCRIPTION
`xesmf` does not test/support python 3.10 yet, so I think we can just use python 3.9 for now.

Closes #181 

cc: @MaceKuailv