### PR TITLE
pin xarray for now

### DIFF
--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - distributed
   - bottleneck
   - netCDF4
-  - xarray
+  - xarray < 2022.6
   - cartopy<0.20
   - esmpy
   - geopy


### PR DESCRIPTION


We are going to also pin (for now) `xarray < 2022.6`. There was a new release last week, with lost of internal changes (based on refactoring), and testing on sciserver this xr version cause an error that with `maskH.where(drop=True)` on the before performing the cutout. The test image on sciserver that Mitya installed has the previous version of xarray (xarray 2022.3), which does not produce the error...

I need to spend some time on this. Again, it may be very small, but likely very sublte. For now will I'll have to pin xarray