### PR TITLE
update Binder environment again 

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - esmpy
   - intake-xarray
   - geopy
-  - xesmf!=0.5.0,!=0.5.1
+  - xesmf
   - esmf
   - xgcm < 0.7
   - Ipython

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: rise-environment
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python
   - numpy
   - matplotlib
   - pandas

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -26,6 +26,5 @@ dependencies:
   - tqdm
   - pip
   - pip:
-    - git+https://github.com/intake/intake-xarray.git
     - git+https://github.com/hainegroup/oceanspy.git
     - jupyter-contrib-nbextensions

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: rise-environment
 channels:
   - conda-forge
 dependencies:
-  - python
+  - python < 3.10
   - numpy
   - matplotlib
   - pandas

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - esmpy
   - intake-xarray
   - geopy
-  - xesmf
+  - xesmf!=0.5.0,!=0.5.1
   - esmf
   - xgcm < 0.7
   - Ipython

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - bottleneck
   - netCDF4
   - xarray < 2022.6
-  - cartopy
+  - cartopy < 0.20
   - esmpy
   - intake-xarray
   - geopy


### PR DESCRIPTION
Closes #249 

Tested. Is able to build the image and run the appropriate notebooks.

The link on the README and documentation are still broken and will need to be corrected once I build the Binder image on the main branch (after merging this PR, unless somebody knows how to create the appropriate binder link before merging the PR). Otherwise, expect another PR to fix those links after merging this one.

