### PR TITLE
Typo when calculating Survey

### DIFF
--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -1077,7 +1077,7 @@ def survey_stations(
     if "YRange" not in kwargs:
         kwargs["YRange"] = [_np.min(Y_surv), _np.max(Y_surv)]
     if "XRange" not in kwargs:
-        kwargs["XRange"] = [_np.min(X_surv), _np.max(Y_surv)]
+        kwargs["XRange"] = [_np.min(X_surv), _np.max(X_surv)]
     if "add_Hbdr" not in kwargs:
         kwargs["add_Hbdr"] = True
     od = od.subsample.cutout(**kwargs)


### PR DESCRIPTION
Minimal change, fixes a typo on the survey captured by Renske (Thanks!). At this stage no new test needs to be incorporated.