### PR TITLE
update oceanspy_test environment

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - geopy
   - xesmf
   - esmf
-  - xgcm
+  - xgcm < 0.7
   - Ipython
   - tqdm
   - pytest
@@ -22,7 +22,7 @@ dependencies:
   - ffmpeg
   - aiohttp
   - pandas
-  - matplotlib
+  - matplotlib < 3.5.3 
   - fsspec!=0.9.0
   - pooch
   - pip

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - distributed
   - bottleneck
   - netCDF4
-  - xarray < 2022.6
+  - xarray
   - cartopy<0.20
   - esmpy
   - geopy
@@ -43,7 +43,7 @@ dependencies:
   - cftime
   - rasterio
   - cfgrib
-  - matplotlib
+  - matplotlib < 3.5.3
   - cf_xarray
   - ipykernel
   - numba


### PR DESCRIPTION
Thanks to @MaceKuailv who figure out that there is an issue with matplotlib version > 3.5.2. See issue #269 for a description. Pinning down allows all tests to pass in my testing environment. It is also the reason the previous PR  #268 passed (we looked and the ci/environment used an even older version of matplotlib, which is why all tests passed. We don't know why it used an older matplotlib version though, but that is a separate issue). 

This PR also unpins xarray, since tests ran fine within the new `oceanspy_test` environment which does not pin xarray . If there is an issue then we can figure out later, but so far all tests passed on my oceanspy_test environment. 

Lets see if things go well...

