### PR TITLE
Minor fix for Old issue 

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - bottleneck
   - netCDF4
   - xarray
-  - cartopy<0.20
+  - cartopy
   - intake-xarray
   - geopy
   - xesmf

--- a/oceanspy/plot.py
+++ b/oceanspy/plot.py
@@ -748,7 +748,7 @@ def horizontal_section(
                 _plt.clabel(cont, **clabel_kwargs)
 
     # Labels and return
-    add_labels = kwargs.pop("add_labels", None)
+    add_labels = kwargs.pop("add_labels", False)
     if len(dims) == 0:
         ax = _plt.gca()
         if od.projection is None:

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -335,7 +335,7 @@ def cutout(
                 _np.fabs(od._ds["YG"].max() - od._ds["YG"].min()),
             ]
         )
-        add_Hbdr = 1.5*add_Hbdr / _np.mean([len(od._ds["X"]), len(od._ds["Y"])])
+        add_Hbdr = 1.5 * add_Hbdr / _np.mean([len(od._ds["X"]), len(od._ds["Y"])])
     elif add_Hbdr is False:
         add_Hbdr = 0
 

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -335,7 +335,7 @@ def cutout(
                 _np.fabs(od._ds["YG"].max() - od._ds["YG"].min()),
             ]
         )
-        add_Hbdr = add_Hbdr / _np.mean([len(od._ds["X"]), len(od._ds["Y"])])
+        add_Hbdr = 1.5*add_Hbdr / _np.mean([len(od._ds["X"]), len(od._ds["Y"])])
     elif add_Hbdr is False:
         add_Hbdr = 0
 
@@ -1090,7 +1090,15 @@ def survey_stations(
     )
 
     # Interpolate
-    regridder = _xe.Regridder(ds_in, ds, **xesmf_regridder_kwargs)
+    try:
+        regridder = _xe.Regridder(ds_in, ds, **xesmf_regridder_kwargs)
+    except ValueError:
+        raise ValueError(
+            """
+        An error occured when creating the xesmf.Regridder object,
+        try add_Hbdr = M, where M>1.5 times horizontal spacing
+        """
+        )
     regridder._grid_in = None  # See https://github.com/JiaweiZhuang/xESMF/issues/71
     regridder._grid_out = None  # See https://github.com/JiaweiZhuang/xESMF/issues/71
     interp_vars = [

--- a/oceanspy/tests/test_compute_functions.py
+++ b/oceanspy/tests/test_compute_functions.py
@@ -470,9 +470,10 @@ def test_survey_aligned_velocities(od_in, gridtype, rotate, survey):
             # Test shortcut
             od_surv.compute.survey_aligned_velocities()
 
-        # Chek velocities
+        # Check velocities
         vel_surv = np.sqrt(od_surv._ds["U"] ** 2 + od_surv._ds["V"] ** 2)
         vel_alig = np.sqrt(ds_out["tan_Vel"] ** 2 + ds_out["ort_Vel"] ** 2)
+        # see issue 70 (https://github.com/hainegroup/oceanspy/issues/70) for more information.
         assert_almost_equal(
             vel_surv.values, vel_alig.values, decimal=4 if rotate else 7
         )

--- a/oceanspy/tests/test_compute_functions.py
+++ b/oceanspy/tests/test_compute_functions.py
@@ -473,7 +473,8 @@ def test_survey_aligned_velocities(od_in, gridtype, rotate, survey):
         # Check velocities
         vel_surv = np.sqrt(od_surv._ds["U"] ** 2 + od_surv._ds["V"] ** 2)
         vel_alig = np.sqrt(ds_out["tan_Vel"] ** 2 + ds_out["ort_Vel"] ** 2)
-        # see issue 70 (https://github.com/hainegroup/oceanspy/issues/70) for more information.
+        # see issue 70 for more information.
+        # https://github.com/hainegroup/oceanspy/issues/70
         assert_almost_equal(
             vel_surv.values, vel_alig.values, decimal=4 if rotate else 7
         )


### PR DESCRIPTION
Add a comment for the issue mentioned in issue #70, which is not really a bug in Oceanspy.

Modified the default add_Hbdr size for issue #136, and added an elegant error message. 

Fixed a bug in plot.py that caused the cartopy/animation issue (#197 ), therefore unpinned cartopy.

When cartopy folks fix the contour/pcolormesh issue, we can unpin matplotlib. #269 