### PR TITLE
add combine nested

### DIFF
--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -162,6 +162,7 @@ sources:
         engine: netcdf4
         concat_dim: T
         parallel: True
+        combine: nested
     metadata:
       rename:
         T: time  
@@ -228,6 +229,7 @@ sources:
         engine: netcdf4
         concat_dim: T
         parallel: True
+        combine: nested
     metadata:
       rename:
         T: time
@@ -382,6 +384,7 @@ sources:
         engine: netcdf4
         concat_dim: T
         parallel: True
+        combine: nested
     metadata:
       rename:
         T: time


### PR DESCRIPTION
Closes #274 

I think the datasets that are failing are experiencing a breaking change in `xarray`. We just have to specify `combine="nested"`.

@ThomasHaine looks like you tested with a different environment. I couldn't reproduce the issue using the Oceanography Image on SciServer (I believe that's because that image uses an old version of xarray).
Could you please run your script again with this version of the catalog?
You just have to specify the catalog url corresponding to this branch:
```python
catalog_url="https://raw.githubusercontent.com/hainegroup/oceanspy/add-combine/sciserver_catalogs/catalog_xarray.yaml"
od = ospy.open_oceandataset.from_catalog(name, catalog_url=catalog_url)
```
(where `name` is the name of the catalogue entry, such as `IGPwinter`)