### PR TITLE
Binder environment correct

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - esmpy
 - intake-xarray
 - geopy
-- xesmf
+- xesmf >= 0.6.4
 - esmf
 - xgcm < 0.7
 - Ipython

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - esmpy
 - intake-xarray
 - geopy
-- xesmf >= 0.6.4
+- xesmf > 0.6.3
 - esmf
 - xgcm < 0.7
 - Ipython

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - cartopy
 - intake-xarray
 - geopy
-- xesmf >= 0.6.4
+- xesmf > 0.6.3
 - esmf
 - xgcm < 0.7
 - Ipython

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - cartopy
 - intake-xarray
 - geopy
-- xesmf
+- xesmf >= 0.6.4
 - esmf
 - xgcm < 0.7
 - Ipython

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - cartopy
 - esmpy
 - geopy
-- xesmf >= 0.6.4
+- xesmf > 0.6.3
 - esmf
 - xgcm < 0.7
 - Ipython

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -8,10 +8,10 @@ dependencies:
 - bottleneck
 - netCDF4
 - xarray
-- cartopy<0.20
+- cartopy
 - esmpy
 - geopy
-- xesmf
+- xesmf >= 0.6.4
 - esmf
 - xgcm < 0.7
 - Ipython


### PR DESCRIPTION
Minimal changes to #303   - 

For some reason the Binder environment got build with an older version of `xesmf` (0.6.3), which yields an error like that described in #291 . This PR fixes that by explicitly requiring a newer version than that (not just on the binder).