### PR TITLE
add llc4320 forcing files to catalog

### DIFF
--- a/oceanspy/open_oceandataset.py
+++ b/oceanspy/open_oceandataset.py
@@ -467,7 +467,7 @@ def _find_entries(name, catalog_url):
     except ValidationError:
         if catalog_url is None:
             url = (
-                "https://raw.githubusercontent.com/Mikejmnez/oceanspy/"
+                "https://raw.githubusercontent.com/hainegroup/oceanspy/"
                 "main/sciserver_catalogs/catalog_xmitgcm.yaml"
             )
         else:

--- a/oceanspy/open_oceandataset.py
+++ b/oceanspy/open_oceandataset.py
@@ -467,7 +467,7 @@ def _find_entries(name, catalog_url):
     except ValidationError:
         if catalog_url is None:
             url = (
-                "https://raw.githubusercontent.com/hainegroup/oceanspy/"
+                "https://raw.githubusercontent.com/Mikejmnez/oceanspy/"
                 "main/sciserver_catalogs/catalog_xmitgcm.yaml"
             )
         else:

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -712,6 +712,41 @@ sources:
       original_output: snapshot
 
 
+  LLC4320_forcing:
+    description: 10 day sample of hourly data from the LLC4320 simulation
+    driver: zarr
+    args:
+      urlpath: '/home/idies/workspace/poseidon/data*/llc4320_tests/10dayhourly/forcing'
+      engine: zarr
+      parallel: true
+    metadata:
+      swap_dims:
+        k: Z
+        k_p1: Zp1
+        k_u: Zu
+        k_l: Zl
+      rename:
+        i: X
+        i_g: Xp1
+        j: Y
+        j_g: Yp1
+      parameters:
+        rSphere: 6.371e+03
+        eq_state: jmd95
+        rho0: 1027
+        g: 9.81
+        eps_nh: 0
+        omega: 7.292123516990373e-05
+        c_p: 3.986e+03
+        tempFrz0: 9.01e-02
+        dTempFrz_dS: -5.75e-02
+      name: LLC4320
+      description: |
+        10 day hourly data from the LLC4320 simulations computed using the MITGCM, a general, curvilinear ocean simulation on the cube-sphere.
+      projection:
+      original_output: snapshot
+
+
   LLC4320_grid:
     description: 10 day sample of hourly data from the LLC4320 simulation
     driver: zarr

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -640,6 +640,7 @@ sources:
         T: time
       original_output: snapshot
 
+
   LLC4320_scalars:
     description: 10 day sample of hourly data from the LLC4320 simulation
     driver: zarr

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -713,6 +713,41 @@ sources:
       original_output: snapshot
 
 
+  # LLC4320_forcing:
+  #   description: 10 day sample of hourly data from the LLC4320 simulation
+  #   driver: zarr
+  #   args:
+  #     urlpath: '/home/idies/workspace/poseidon/data*/llc4320_tests/10dayhourly/forcing'
+  #     engine: zarr
+  #     parallel: true
+  #   metadata:
+  #     swap_dims:
+  #       k: Z
+  #       k_p1: Zp1
+  #       k_u: Zu
+  #       k_l: Zl
+  #     rename:
+  #       i: X
+  #       i_g: Xp1
+  #       j: Y
+  #       j_g: Yp1
+  #     parameters:
+  #       rSphere: 6.371e+03
+  #       eq_state: jmd95
+  #       rho0: 1027
+  #       g: 9.81
+  #       eps_nh: 0
+  #       omega: 7.292123516990373e-05
+  #       c_p: 3.986e+03
+  #       tempFrz0: 9.01e-02
+  #       dTempFrz_dS: -5.75e-02
+  #     name: LLC4320
+  #     description: |
+  #       10 day hourly data from the LLC4320 simulations computed using the MITGCM, a general, curvilinear ocean simulation on the cube-sphere.
+  #     projection:
+  #     original_output: snapshot
+
+
   LLC4320_grid:
     description: 10 day sample of hourly data from the LLC4320 simulation
     driver: zarr

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -713,41 +713,6 @@ sources:
       original_output: snapshot
 
 
-  LLC4320_forcing:
-    description: 10 day sample of hourly data from the LLC4320 simulation
-    driver: zarr
-    args:
-      urlpath: '/home/idies/workspace/poseidon/data*/llc4320_tests/10dayhourly/forcing'
-      engine: zarr
-      parallel: true
-    metadata:
-      swap_dims:
-        k: Z
-        k_p1: Zp1
-        k_u: Zu
-        k_l: Zl
-      rename:
-        i: X
-        i_g: Xp1
-        j: Y
-        j_g: Yp1
-      parameters:
-        rSphere: 6.371e+03
-        eq_state: jmd95
-        rho0: 1027
-        g: 9.81
-        eps_nh: 0
-        omega: 7.292123516990373e-05
-        c_p: 3.986e+03
-        tempFrz0: 9.01e-02
-        dTempFrz_dS: -5.75e-02
-      name: LLC4320
-      description: |
-        10 day hourly data from the LLC4320 simulations computed using the MITGCM, a general, curvilinear ocean simulation on the cube-sphere.
-      projection:
-      original_output: snapshot
-
-
   LLC4320_grid:
     description: 10 day sample of hourly data from the LLC4320 simulation
     driver: zarr

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -713,39 +713,39 @@ sources:
       original_output: snapshot
 
 
-  # LLC4320_forcing:
-  #   description: 10 day sample of hourly data from the LLC4320 simulation
-  #   driver: zarr
-  #   args:
-  #     urlpath: '/home/idies/workspace/poseidon/data*/llc4320_tests/10dayhourly/forcing'
-  #     engine: zarr
-  #     parallel: true
-  #   metadata:
-  #     swap_dims:
-  #       k: Z
-  #       k_p1: Zp1
-  #       k_u: Zu
-  #       k_l: Zl
-  #     rename:
-  #       i: X
-  #       i_g: Xp1
-  #       j: Y
-  #       j_g: Yp1
-  #     parameters:
-  #       rSphere: 6.371e+03
-  #       eq_state: jmd95
-  #       rho0: 1027
-  #       g: 9.81
-  #       eps_nh: 0
-  #       omega: 7.292123516990373e-05
-  #       c_p: 3.986e+03
-  #       tempFrz0: 9.01e-02
-  #       dTempFrz_dS: -5.75e-02
-  #     name: LLC4320
-  #     description: |
-  #       10 day hourly data from the LLC4320 simulations computed using the MITGCM, a general, curvilinear ocean simulation on the cube-sphere.
-  #     projection:
-  #     original_output: snapshot
+  LLC4320_forcing:
+    description: 10 day sample of hourly data from the LLC4320 simulation
+    driver: zarr
+    args:
+      urlpath: '/home/idies/workspace/poseidon/data*/llc4320_tests/10dayhourly/forcing'
+      engine: zarr
+      parallel: true
+    metadata:
+      swap_dims:
+        k: Z
+        k_p1: Zp1
+        k_u: Zu
+        k_l: Zl
+      rename:
+        i: X
+        i_g: Xp1
+        j: Y
+        j_g: Yp1
+      parameters:
+        rSphere: 6.371e+03
+        eq_state: jmd95
+        rho0: 1027
+        g: 9.81
+        eps_nh: 0
+        omega: 7.292123516990373e-05
+        c_p: 3.986e+03
+        tempFrz0: 9.01e-02
+        dTempFrz_dS: -5.75e-02
+      name: LLC4320
+      description: |
+        10 day hourly data from the LLC4320 simulations computed using the MITGCM, a general, curvilinear ocean simulation on the cube-sphere.
+      projection:
+      original_output: snapshot
 
 
   LLC4320_grid:


### PR DESCRIPTION
I have transformed the forcing files into zarr from binary and are now available through Sciserver. I have added an entry on the intake catalog to load them when reading llc4320 data.