### PR TITLE
fix toml prettifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     args: [--autofix, --preserve-quotes]
   - id: pretty-format-toml
     args: [--autofix]
+    additional_dependencies: [toml-sort<0.22.0]
 - repo: https://github.com/pycqa/isort
   rev: 5.11.4
   hooks:


### PR DESCRIPTION
@Mikejmnez  see: https://github.com/macisamuele/language-formatters-pre-commit-hooks/issues/133
It's not clear whether the project is actively maintained. We can also remove the hook, up to you.
