### PR TITLE
Rename to Temp and S

### DIFF
--- a/oceanspy/llc_rearrange.py
+++ b/oceanspy/llc_rearrange.py
@@ -114,7 +114,6 @@ class LLCtransformation:
 
         https://docs.xarray.dev/en/stable/generated/xarray.Dataset.chunk.html
 
-
         See Also
         --------
         subsample.cutout

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -655,8 +655,8 @@ sources:
         k_u: Zu
         k_l: Zl
       rename:
-        Theta: THETA
-        Salt: SALT
+        Theta: Temp
+        Salt: S
         i: X
         i_g: Xp1
         j: Y


### PR DESCRIPTION
closes iss #316  by renaming the temperature and salinity variables to `Temp` and `S`. These are snapshots and not montly averaged like in ECCO.