### PR TITLE
masking and dataset list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ oceanspy/tests/Data
 version.py
 
 # dynamic docs
-# docs/datasets.rst
+docs/datasets.rst
 docs/generated/
 
 # Created by https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vim,visualstudiocode,pycharm

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ oceanspy/tests/Data
 version.py
 
 # dynamic docs
-docs/datasets.rst
+# docs/datasets.rst
 docs/generated/
 
 # Created by https://www.toptal.com/developers/gitignore/api/python,jupyternotebooks,vim,visualstudiocode,pycharm

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -238,7 +238,7 @@ f = urllib.request.urlopen(url)
 SCISERVER_DATASETS = yaml.safe_load(f)["datasets"]["sciserver"]
 
 for name in SCISERVER_DATASETS:
-    if name in ["Arctic_Control", "LLC4320", "ECCO", "HYCOM"]:
+    if name in ["Arctic_Control", "LLC4320", "HYCOM"]:
         continue
 
     # Section

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -323,22 +323,6 @@ Run the following code to open the dataset:
     import oceanspy as ospy
     od = ospy.open_oceandataset.from_catalog('KangerFjord')
 
-.. _daily_ecco:
-
-----------
-daily_ecco
-----------
-
-ECCO_ v4r4 3D dataset, ocean simulations on LLC90 grid
-
-Run the following code to open the dataset:
-
-.. code-block:: ipython
-    :class: no-execute
-
-    import oceanspy as ospy
-    od = ospy.open_oceandataset.from_catalog('daily_ecco')
-
 
 .. _ECCO:
 
@@ -346,7 +330,7 @@ Run the following code to open the dataset:
 ECCO
 ----
 
-A 3D dataset of monthly-averaged ocean model output from ECCO_ v4r4, defined
+A 3D dataset of monthly-averaged ocean model output from ECCO_v4r4, defined
 on LLC90 grid.
 
 Run the following code to open the dataset:
@@ -356,6 +340,23 @@ Run the following code to open the dataset:
 
     import oceanspy as ospy
     od = ospy.open_oceandataset.from_catalog('ECCO')
+
+.. _daily_ecco:
+
+----------
+daily_ecco
+----------
+
+ECCO_v4r4 3D dataset, ocean simulations on LLC90 grid
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('daily_ecco')
+
 
 
 .. _`Almansi et al., 2017 - JPO.`: https://journals.ametsoc.org/doi/full/10.1175/JPO-D-17-0129.1

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -1,0 +1,363 @@
+.. _datasets:
+
+========
+Datasets
+========
+
+List of datasets available on SciServer.
+
+.. _get_started:
+
+-----------
+get_started
+-----------
+
+Small cutout from EGshelfIIseas2km_ASR_crop_.
+Citation:
+
+* Almansi et al., 2020 - GRL.
+
+See also:
+
+* EGshelfIIseas2km_ASR_full_: Full domain without variables to close budgets.
+* EGshelfIIseas2km_ASR_crop_: Cropped domain with variables to close budgets.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('get_started')
+
+.. _IGPwinter:
+
+---------
+IGPwinter
+---------
+
+High-resolution numerical simulation carried out in parallel to the observational
+component of the Iceland Greenland Seas Project (IGP).
+Citation:
+
+* Renfrew et al., 2019 - BAMS.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('IGPwinter')
+
+.. _EGshelfIIseas2km_ASR_full:
+
+-------------------------
+EGshelfIIseas2km_ASR_full
+-------------------------
+
+High-resolution (~2km) numerical simulation covering the east Greenland shelf (EGshelf),
+and the Iceland and Irminger Seas (IIseas) forced by the Arctic System Reanalysis (ASR).
+Citation:
+
+* Almansi et al., 2020 - GRL.
+
+Characteristics:
+
+* full: Full domain without variables to close budgets.
+
+See also:
+
+* EGshelfIIseas2km_ASR_crop_: Cropped domain with variables to close budgets.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('EGshelfIIseas2km_ASR_full')
+
+.. _EGshelfIIseas2km_ASR_crop:
+
+-------------------------
+EGshelfIIseas2km_ASR_crop
+-------------------------
+
+High-resolution (~2km) numerical simulation covering the east Greenland shelf (EGshelf),
+and the Iceland and Irminger Seas (IIseas) forced by the Arctic System Reanalysis (ASR).
+Citation:
+
+* Almansi et al., 2020 - GRL.
+
+Characteristics:
+
+* crop: Cropped domain with variables to close budgets.
+
+See also:
+
+* EGshelfIIseas2km_ASR_full_: Full domain without variables to close budgets.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('EGshelfIIseas2km_ASR_crop')
+
+.. _EGshelfIIseas2km_ERAI_6H:
+
+------------------------
+EGshelfIIseas2km_ERAI_6H
+------------------------
+
+High-resolution (~2km) numerical simulation covering the east Greenland shelf (EGshelf),
+and the Iceland and Irminger Seas (IIseas) forced by ERA-Interim.
+Citation:
+
+* `Almansi et al., 2017 - JPO.`_
+
+Characteristics:
+
+* 6H: 6-hour resolution without sea ice and external forcing variables.
+
+See also:
+
+* EGshelfIIseas2km_ERAI_1D_: 1-day resolution with sea ice and external forcing variables.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('EGshelfIIseas2km_ERAI_6H')
+
+.. _EGshelfIIseas2km_ERAI_1D:
+
+------------------------
+EGshelfIIseas2km_ERAI_1D
+------------------------
+
+High-resolution (~2km) numerical simulation covering the east Greenland shelf (EGshelf),
+and the Iceland and Irminger Seas (IIseas) forced by ERA-Interim.
+Citation:
+
+* `Almansi et al., 2017 - JPO.`_
+
+Characteristics:
+
+* 1D: 1-day resolution with sea ice and external forcing variables.
+
+See also:
+
+* EGshelfIIseas2km_ERAI_6H_: 6-hour resolution without sea ice and external forcing variables.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('EGshelfIIseas2km_ERAI_1D')
+
+.. _EGshelfSJsec500m_3H_hydro:
+
+-------------------------
+EGshelfSJsec500m_3H_hydro
+-------------------------
+
+Very high-resolution (500m) numerical simulation covering the east Greenland shelf (EGshelf)
+and the Spill Jet section (SJsec). Hydrostatic solutions.
+
+Citation:
+
+* `Magaldi and Haine, 2015 - DSR.`_
+
+Characteristics:
+
+* 3H:    3-hour resolution without external forcing variables.
+* hydro: Hydrostatic solutions.
+
+See also:
+
+* EGshelfSJsec500m_6H_hydro_:    6-hour resolution with external forcing variables. Hydrostatic.
+* EGshelfSJsec500m_6H_NONhydro_: 6-hour resolution with external forcing variables. Non-Hydrostatic.
+* EGshelfSJsec500m_3H_NONhydro_: 3-hour resolution without external forcing variables. Non-Hydrostatic.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('EGshelfSJsec500m_3H_hydro')
+
+.. _EGshelfSJsec500m_6H_hydro:
+
+-------------------------
+EGshelfSJsec500m_6H_hydro
+-------------------------
+
+Very high-resolution (500m) numerical simulation covering the east Greenland shelf (EGshelf)
+and the Spill Jet section (SJsec). Hydrostatic solutions.
+
+Citation:
+
+* `Magaldi and Haine, 2015 - DSR.`_
+
+Characteristics:
+
+* 6H:    6-hour resolution with external forcing variables.
+* hydro: Hydrostatic solutions.
+
+See also:
+
+* EGshelfSJsec500m_3H_hydro_:    3-hour resolution without external forcing variables. Hydrostatic.
+* EGshelfSJsec500m_6H_NONhydro_: 6-hour resolution with external forcing variables. Non-Hydrostatic.
+* EGshelfSJsec500m_3H_NONhydro_: 3-hour resolution without external forcing variables. Non-Hydrostatic.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('EGshelfSJsec500m_6H_hydro')
+
+.. _EGshelfSJsec500m_3H_NONhydro:
+
+----------------------------
+EGshelfSJsec500m_3H_NONhydro
+----------------------------
+
+Very high-resolution (500m) numerical simulation covering the east Greenland shelf (EGshelf)
+and the Spill Jet section (SJsec). Non-Hydrostatic solutions.
+
+Citation:
+
+* `Magaldi and Haine, 2015 - DSR.`_
+
+Characteristics:
+
+* 3H:       3-hour resolution without external forcing variables.
+* NONhydro: Non-Hydrostatic solutions.
+
+See also:
+
+* EGshelfSJsec500m_6H_NONhydro_: 6-hour resolution with external forcing variables. Non-Hydrostatic.
+* EGshelfSJsec500m_6H_hydro_:    6-hour resolution with external forcing variables. Hydrostatic.
+* EGshelfSJsec500m_3H_hydro_:    3-hour resolution without external forcing variables. Hydrostatic.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('EGshelfSJsec500m_3H_NONhydro')
+
+.. _EGshelfSJsec500m_6H_NONhydro:
+
+----------------------------
+EGshelfSJsec500m_6H_NONhydro
+----------------------------
+
+Very high-resolution (500m) numerical simulation covering the east Greenland shelf (EGshelf)
+and the Spill Jet section (SJsec). Non-Hydrostatic solutions.
+
+Citation:
+
+* `Magaldi and Haine, 2015 - DSR.`_
+
+Characteristics:
+
+* 6H:       6-hour resolution with external forcing variables.
+* NONhydro: NONHydrostatic solutions.
+
+See also:
+
+* EGshelfSJsec500m_3H_NONhydro_: 3-hour resolution without external forcing variables. Non-Hydrostatic.
+* EGshelfSJsec500m_6H_hydro_:    6-hour resolution with external forcing variables. Hydrostatic.
+* EGshelfSJsec500m_3H_hydro_:    3-hour resolution without external forcing variables. Hydrostatic.
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('EGshelfSJsec500m_6H_NONhydro')
+
+.. _KangerFjord:
+
+-----------
+KangerFjord
+-----------
+
+A realistic numerical model constructed to simulate the oceanic conditions
+and circulation in a large southeast Greenland fjord (Kangerdlugssuaq) and
+the adjacent shelf sea region during winter 2007–2008.
+
+Citation:
+
+* `Fraser et al., 2018 - JGR.`_
+
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('KangerFjord')
+
+.. _daily_ecco:
+
+----------
+daily_ecco
+----------
+
+ECCO_ v4r4 3D dataset, ocean simulations on LLC90 grid
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('daily_ecco')
+
+
+.. _ECCO:
+
+----
+ECCO
+----
+
+A 3D dataset of monthly-averaged ocean model output from ECCO_ v4r4, defined
+on LLC90 grid.
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('ECCO')
+
+
+.. _`Almansi et al., 2017 - JPO.`: https://journals.ametsoc.org/doi/full/10.1175/JPO-D-17-0129.1
+.. _`Magaldi and Haine, 2015 - DSR.`: https://www.sciencedirect.com/science/article/pii/S0967063714001915
+.. _`Fraser et al., 2018 - JGR.`: https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2018JC014435

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -323,6 +323,22 @@ Run the following code to open the dataset:
     import oceanspy as ospy
     od = ospy.open_oceandataset.from_catalog('KangerFjord')
 
+.. _ECCO:
+
+----
+ECCO
+----
+
+ECCO_ v4r4 3D dataset, ocean simulations on LLC90 grid
+
+Run the following code to open the dataset:
+
+.. code-block:: ipython
+    :class: no-execute
+
+    import oceanspy as ospy
+    od = ospy.open_oceandataset.from_catalog('ECCO')
+
 .. _daily_ecco:
 
 ----------

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -323,31 +323,13 @@ Run the following code to open the dataset:
     import oceanspy as ospy
     od = ospy.open_oceandataset.from_catalog('KangerFjord')
 
-
-.. _ECCO:
-
-----
-ECCO
-----
-
-A 3D dataset of monthly-averaged ocean model output from ECCO_v4r4, defined
-on LLC90 grid.
-
-Run the following code to open the dataset:
-
-.. code-block:: ipython
-    :class: no-execute
-
-    import oceanspy as ospy
-    od = ospy.open_oceandataset.from_catalog('ECCO')
-
 .. _daily_ecco:
 
 ----------
 daily_ecco
 ----------
 
-ECCO_v4r4 3D dataset, ocean simulations on LLC90 grid
+ECCO_ v4r4 3D dataset, ocean simulations on LLC90 grid
 
 Run the following code to open the dataset:
 
@@ -356,8 +338,6 @@ Run the following code to open the dataset:
 
     import oceanspy as ospy
     od = ospy.open_oceandataset.from_catalog('daily_ecco')
-
-
 
 .. _`Almansi et al., 2017 - JPO.`: https://journals.ametsoc.org/doi/full/10.1175/JPO-D-17-0129.1
 .. _`Magaldi and Haine, 2015 - DSR.`: https://www.sciencedirect.com/science/article/pii/S0967063714001915

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -246,7 +246,7 @@ def cutout(
 
         # Find time indexes
         maskT = maskT.assign_coords(time=_np.arange(len(maskT["time"])))
-        dmaskT = maskT.where(maskT, drop=True)
+        dmaskT = maskT.where(maskT.compute(), drop=True)
         dtime = dmaskT["time"].values
         iT = [min(dtime), max(dtime)]
         maskT["time"] = ds["time"]
@@ -298,7 +298,7 @@ def cutout(
 
         # Find vertical indexes
         maskV = maskV.assign_coords(Zp1=_np.arange(len(maskV["Zp1"])))
-        dmaskV = maskV.where(maskV, drop=True)
+        dmaskV = maskV.where(maskV.compute(), drop=True)
         dZp1 = dmaskV["Zp1"].values
         iZ = [_np.min(dZp1), _np.max(dZp1)]
         maskV["Zp1"] = ds["Zp1"]
@@ -529,13 +529,13 @@ def cutout(
 
         for var in ds.data_vars:
             if set(["X", "Y"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskC, drop=True)
+                ds[var] = ds[var].where(maskC.compute(), drop=True)
             elif set(["Xp1", "Yp1"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskG, drop=True)
+                ds[var] = ds[var].where(maskG.compute(), drop=True)
             elif set(["Xp1", "Y"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskU, drop=True)
+                ds[var] = ds[var].where(maskU.compute(), drop=True)
             elif set(["X", "Yp1"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskV, drop=True)
+                ds[var] = ds[var].where(maskV.compute(), drop=True)
 
     # ---------------------------
     # TIME RESAMPLING

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -492,7 +492,7 @@ def cutout(
             ),
             1,
             0,
-        ).compute()
+        ).persist()
         maskG = _xr.where(
             _np.logical_and(
                 _np.logical_and(ds["YG"] >= minY, ds["YG"] <= maxY),
@@ -503,7 +503,7 @@ def cutout(
             ),
             1,
             0,
-        ).compute()
+        ).persist()
         maskU = _xr.where(
             _np.logical_and(
                 _np.logical_and(ds["YU"] >= minY, ds["YU"] <= maxY),
@@ -514,7 +514,7 @@ def cutout(
             ),
             1,
             0,
-        ).compute()
+        ).persist()
         maskV = _xr.where(
             _np.logical_and(
                 _np.logical_and(ds["YV"] >= minY, ds["YV"] <= maxY),
@@ -525,17 +525,17 @@ def cutout(
             ),
             1,
             0,
-        ).compute()
+        ).persist()
 
         for var in ds.data_vars:
             if set(["X", "Y"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskC, drop=True)
+                ds[var] = ds[var].where(maskC.compute(), drop=True)
             elif set(["Xp1", "Yp1"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskG, drop=True)
+                ds[var] = ds[var].where(maskG.compute(), drop=True)
             elif set(["Xp1", "Y"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskU, drop=True)
+                ds[var] = ds[var].where(maskU.compute(), drop=True)
             elif set(["X", "Yp1"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskV, drop=True)
+                ds[var] = ds[var].where(maskV.compute(), drop=True)
 
     # ---------------------------
     # TIME RESAMPLING

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -492,7 +492,7 @@ def cutout(
             ),
             1,
             0,
-        ).persist()
+        ).compute()
         maskG = _xr.where(
             _np.logical_and(
                 _np.logical_and(ds["YG"] >= minY, ds["YG"] <= maxY),
@@ -503,7 +503,7 @@ def cutout(
             ),
             1,
             0,
-        ).persist()
+        ).compute()
         maskU = _xr.where(
             _np.logical_and(
                 _np.logical_and(ds["YU"] >= minY, ds["YU"] <= maxY),
@@ -514,7 +514,7 @@ def cutout(
             ),
             1,
             0,
-        ).persist()
+        ).compute()
         maskV = _xr.where(
             _np.logical_and(
                 _np.logical_and(ds["YV"] >= minY, ds["YV"] <= maxY),
@@ -525,17 +525,17 @@ def cutout(
             ),
             1,
             0,
-        ).persist()
+        ).compute()
 
         for var in ds.data_vars:
             if set(["X", "Y"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskC.compute(), drop=True)
+                ds[var] = ds[var].where(maskC, drop=True)
             elif set(["Xp1", "Yp1"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskG.compute(), drop=True)
+                ds[var] = ds[var].where(maskG, drop=True)
             elif set(["Xp1", "Y"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskU.compute(), drop=True)
+                ds[var] = ds[var].where(maskU, drop=True)
             elif set(["X", "Yp1"]).issubset(ds[var].dims):
-                ds[var] = ds[var].where(maskV.compute(), drop=True)
+                ds[var] = ds[var].where(maskV, drop=True)
 
     # ---------------------------
     # TIME RESAMPLING

--- a/sciserver_catalogs/catalog_xarray.yaml
+++ b/sciserver_catalogs/catalog_xarray.yaml
@@ -865,7 +865,7 @@ sources:
         tempFrz0: 9.01e-02
         dTempFrz_dS: -5.75e-02
       name: ECCO_v4r4
-      description: ECCO v4r4 3D dataset, ocean simulations on LLC90 grid
+      description: ECCO v4r4 3D dataset, ocean simulations on LLC90 grid (monthly mean output)
       citation:
       projection:
       original_output: monthly mean
@@ -904,10 +904,10 @@ sources:
         tempFrz0: 9.01e-02
         dTempFrz_dS: -5.75e-02
       name: ECCO_v4r4
-      description: ECCO v4r4 3D dataset, ocean simulations on LLC90 grid
+      description: ECCO v4r4 3D dataset, ocean simulations on LLC90 grid (daily output)
       citation:
       projection:
-      original_output: monthly mean
+      original_output: daily output
 
 # ECCOv4r4 data daily
   daily_ecco_snap:
@@ -922,10 +922,10 @@ sources:
       parallel: true
     metadata:
       name: ECCO_v4r4
-      description: ECCO v4r4 3D dataset, ocean simulations on LLC90 grid
+      description: ECCO v4r4 3D dataset, ocean simulations on LLC90 grid (daily mean)
       citation:
       projection:
-      original_output: daily snapshot
+      original_output: daily mean
 
 # ECCOv4r4 data daily
   daily_ecco_mean:


### PR DESCRIPTION
This PR adresses issues  #341 and #342 by:

- Sets `mask.compute()` explicitly .
- Includes ECCO on the website's dataset list.

