### PR TITLE
Iss386

### DIFF
--- a/oceanspy/_ospy_utils.py
+++ b/oceanspy/_ospy_utils.py
@@ -6,6 +6,7 @@ import warnings
 
 # Import modules (can be public here)
 import numpy
+import xarray as _xr
 import xgcm
 
 
@@ -158,12 +159,25 @@ def _check_range(od, obj, objName):
     -------
     obj: Range object
     """
+
+    if "face" in od._ds.dims and od._ds.dims["face"] == 13:
+        cdata = {
+            "XG": ("XG", numpy.asarray([-180, 180], dtype=od._ds["XG"].dtype)),
+            "YG": ("YG", numpy.asarray([-90, 90], dtype=od._ds["YG"].dtype)),
+            "Zp1": od._ds["Zp1"],
+            "time": od._ds["time"],
+        }
+        data = _xr.Dataset(cdata)
+    else:
+        data = od._ds
+
+    # main loop
     if obj is not None:
         prefs = ["Y", "X", "Z", "time"]
         coords = ["YG", "XG", "Zp1", "time"]
         for _, (pref, coord) in enumerate(zip(prefs, coords)):
             if pref in objName:
-                valchek = od._ds[coord]
+                valchek = data[coord]
                 break
         obj = numpy.asarray(obj, dtype=valchek.dtype)
         if obj.ndim == 0:

--- a/oceanspy/llc_rearrange.py
+++ b/oceanspy/llc_rearrange.py
@@ -413,8 +413,6 @@ class LLCtransformation:
 
         DS = _LLC_check_sizes(DS)
 
-        # rechunk data. In the ECCO data this is done automatically
-
         if "nYG" in DS.reset_coords().data_vars:
             DS = DS.drop_vars(_var_)
 

--- a/oceanspy/llc_rearrange.py
+++ b/oceanspy/llc_rearrange.py
@@ -67,9 +67,7 @@ class LLCtransformation:
         YRange=None,
         faces=None,
         centered=None,
-        chunks=None,
         persist=False,
-        geo_true=False,
     ):
         """This transformation splits the arctic cap (face=6) into four triangular
         regions and combines all faces in a quasi lat-lon grid. The triangular
@@ -103,16 +101,9 @@ class LLCtransformation:
             If 'Pacific', the transformed data has a layout in which the Pacific Ocean
             lies at the center of the domain.
             This option is only relevant when transforming the entire dataset.
-        chunks: bool or dict.
-            If False (default) - chunking is automatic.
-            If dict, rechunks the dataset according to the spefications of the
-            dictionary. See `xarray.Dataset.chunk()`.
         persist: bool.
             If `False` (default), transformation of rotated and arctic data is not
             persisted. See `xarray.Dataset.persist()`.
-        geo_true: bool.
-            If `True` the U and V velocities are corrected and aligned to geographical
-            coordinates. If `False` (default) these are not.
 
         Returns
         -------
@@ -423,14 +414,9 @@ class LLCtransformation:
         DS = _LLC_check_sizes(DS)
 
         # rechunk data. In the ECCO data this is done automatically
-        if chunks:
-            DS = DS.chunk(chunks)
 
         if "nYG" in DS.reset_coords().data_vars:
             DS = DS.drop_vars(_var_)
-
-        if geo_true:
-            DS = llc_local_to_lat_lon(DS)
 
         # restore original attrs if lost
         for var in varList:

--- a/oceanspy/llc_rearrange.py
+++ b/oceanspy/llc_rearrange.py
@@ -1110,6 +1110,7 @@ def _LLC_check_sizes(_DS):
     if Nx_c == Nx_g:
         arg = {dims_c.X: slice(0, -1)}
         _DS = _copy.deepcopy(_DS.isel(**arg))
+        Nx_c = len(_DS[dims_c.X])
     else:
         delta = Nx_g - Nx_c
         if delta < 0:
@@ -1119,13 +1120,20 @@ def _LLC_check_sizes(_DS):
             )
         else:
             if delta == 2:  # len(_g) = len(_c)+2. Can but shouldn't happen.
-                arg = {dims_g: slice(0, -1)}
+                arg = {dims_g.X: slice(0, -1)}
                 _DS = _copy.deepcopy(_DS.isel(**arg))
+                Nx_g = len(_DS[dims_g.X])
+
     if Ny_c == Ny_g:
         arg = {dims_c.Y: slice(0, -1)}
         _DS = _copy.deepcopy(_DS.isel(**arg))
+        Ny_c = len(_DS[dims_c.Y])
 
-    return _DS
+    # lastly, make sure that core dimensions are chunked consistently
+
+    chunks = {"X": Nx_c, "Xp1": Nx_g, "Y": Ny_c, "Yp1": Ny_g}
+
+    return _DS.chunk(**chunks)
 
 
 def _reorder_ds(_ds, dims_c, dims_g):

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -67,9 +67,7 @@ def cutout(
     sampMethod="snapshot",
     dropAxes=False,
     centered=None,
-    chunks=None,
     persist=False,
-    geo_true=False,
 ):
     """
     Cutout the original dataset in space and time
@@ -362,9 +360,7 @@ def cutout(
             "XRange": XRange,
             "YRange": YRange,
             "centered": centered,
-            "chunks": chunks,
             "persist": persist,
-            "geo_true": geo_true,
         }
         dsnew = _llc_trans.arctic_crown(**arg)
         dsnew = dsnew.set_coords(co_list)


### PR DESCRIPTION
This PR addresses #386 .

Improves the performance of oceanspy with LLC4320 by avoiding the computation of max/min range values from the dataset, as these are known a priori.

Feel free to suggest something different, not approve, etc... 

This PR also makes sure that the chunk size in the horizontal of the resulting dataset from cutout, is set by the domain size. Before it was an option, with the idea for testing. But we can always re chunk afterwards. This eliminates an unused parameter from llc_rearrange.

