### PR TITLE
Iss389

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: rise-environment
 channels:
 - conda-forge
 dependencies:
-- python=3.11
+- python=3.10
 - numpy
 - matplotlib
 - pandas

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: rise-environment
 channels:
 - conda-forge
 dependencies:
-- python
+- python=3.10
 - numpy
 - matplotlib
 - pandas

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: rise-environment
 channels:
 - conda-forge
 dependencies:
-- python=3.10
+- python=3.11
 - numpy
 - matplotlib
 - pandas


### PR DESCRIPTION
To generate binder build, I pin the python to 3.10. Otherwise it tried to install / upgrade during installation to 3.11, which then fails to build.

see #389 