### PR TITLE
replacing rise with jupyterlab-rise allows binder to get build

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -7,7 +7,6 @@ dependencies:
 - matplotlib
 - pandas
 - bokeh
-- rise
 - dask
 - distributed
 - bottleneck
@@ -29,3 +28,4 @@ dependencies:
 - pip:
   - git+https://github.com/hainegroup/oceanspy.git
   - jupyter-contrib-nbextensions
+  - jupyterlab-rise

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: rise-environment
 channels:
 - conda-forge
 dependencies:
-- python=3.10
+- python
 - numpy
 - matplotlib
 - pandas


### PR DESCRIPTION
- [] Addresses and closes #389 
- [] builds the binder in my local computer
- [] unpins python in the binder environment

 