### PR TITLE
remove pin to intake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,14 +31,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Conda environment with Micromamba
-      uses: mamba-org/provision-with-micromamba@v16
+      uses: mamba-org/setup-micromamba@v1 # provision-with-micromamba deprecated
       with:
         environment-file: ci/environment.yml
         environment-name: oceanspy_test
-        channels: conda-forge
-        cache-env: true
-        extra-specs: |
+        create-args: >-
           python=${{ matrix.python-version }}
+        cache-environment: true
 
     - name: Set up conda environment
       run: |

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,7 +10,6 @@ dependencies:
 - xoak
 - cartopy
 - scipy
-- intake = 0.7
 - intake-xarray
 - geopy
 - xesmf > 0.6.3

--- a/oceanspy/tests/conftest.py
+++ b/oceanspy/tests/conftest.py
@@ -8,9 +8,9 @@ from pooch import Untar
 # Download data if necessary
 def pytest_configure():
     fnames = pooch.retrieve(
-        url="https://zenodo.org/record/5832607/files/Data.tar.gz?download=1",
+        url="https://zenodo.org/record/10702842/files/Data.tar.gz?download=1",
         processor=Untar(),
-        known_hash="98b2bfadefa62dd223224c797354f9266b54143c2af3c4b6fe676d8547e7d5ee",
+        known_hash="md5:7eff5e5573306c8c08af83a41985970a",
     )
     symlink_args = dict(
         src=f"{os.path.commonpath(fnames)}",

--- a/oceanspy/tests/conftest.py
+++ b/oceanspy/tests/conftest.py
@@ -8,9 +8,9 @@ from pooch import Untar
 # Download data if necessary
 def pytest_configure():
     fnames = pooch.retrieve(
-        url="https://zenodo.org/record/10713953/files/Data.tar.gz?download=1",
+        url="https://zenodo.org/record/10720195/files/Data.tar.gz?download=1",
         processor=Untar(),
-        known_hash="md5:92a2e858a6ba1c37d37fedbd5e932797",
+        known_hash="md5:ecbbd609cd7e185c862c08b92304b7d4",
     )
     symlink_args = dict(
         src=f"{os.path.commonpath(fnames)}",

--- a/oceanspy/tests/conftest.py
+++ b/oceanspy/tests/conftest.py
@@ -8,9 +8,9 @@ from pooch import Untar
 # Download data if necessary
 def pytest_configure():
     fnames = pooch.retrieve(
-        url="https://zenodo.org/record/10702842/files/Data.tar.gz?download=1",
+        url="https://zenodo.org/record/10713953/files/Data.tar.gz?download=1",
         processor=Untar(),
-        known_hash="md5:7eff5e5573306c8c08af83a41985970a",
+        known_hash="md5:92a2e858a6ba1c37d37fedbd5e932797",
     )
     symlink_args = dict(
         src=f"{os.path.commonpath(fnames)}",

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -54,7 +54,6 @@ dependencies:
 - imageio
 - pre-commit
 - xmitgcm
-- intake = 0.7
 - intake-xarray
 - pip:
   - black-nb


### PR DESCRIPTION
I expect some test to fail but overall should close #415 

- [x] All tests pass locally with the appropriate modifications to yaml files in the test data folder Data. 

## Reason I expect test to fail?:

The Data subfolder that is used for some testings is downloaded directly from zenodo: 
The following snippet I copied directly from CI testing .
```Downloading data from 'https://zenodo.org/record/5832607/files/Data.tar.gz?download=1' to file '/home/runner/.cache/pooch/8cba001ed979f3b28c5ae4e283495e67-Data.tar.gz'.```

During CI testing,  Data.tar is downloaded and untarred. `Data` contains testing data along  yaml catalogs that need to be updated to be compatible with both Intake versions  `0.7` and `2.0+`. See #415 

To have successful tests we need

- [x] Modify the yaml files in `https://zenodo.org/record/5832607/files/Data.tar.gz?` following the recommendation in #415 . See also #417 

I don't particularly have access to such data.

After the files have been modified, we can re run the failed CI - tests. Once all CI jobs have passed, we can merge and close #415 

