### PR TITLE
provision with micromamba deprecated

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,14 +31,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Conda environment with Micromamba
-      uses: mamba-org/provision-with-micromamba@v16
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: ci/environment.yml
         environment-name: oceanspy_test
-        channels: conda-forge
-        cache-env: true
-        extra-specs: |
+        extra-specs: >-
           python=${{ matrix.python-version }}
+        cache-environment: true
 
     - name: Set up conda environment
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
       with:
         environment-file: ci/environment.yml
         environment-name: oceanspy_test
-        extra-specs: >-
+        create-args: >-
           python=${{ matrix.python-version }}
         cache-environment: true
 


### PR DESCRIPTION
this is affecting CI github workflows

see https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba