### PR TITLE
Intake2

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - xoak
 - cartopy
 - scipy
-- intake = 0.7
+- intake
 - intake-xarray
 - geopy
 - xesmf > 0.6.3

--- a/oceanspy/tests/conftest.py
+++ b/oceanspy/tests/conftest.py
@@ -8,9 +8,9 @@ from pooch import Untar
 # Download data if necessary
 def pytest_configure():
     fnames = pooch.retrieve(
-        url="https://zenodo.org/record/5832607/files/Data.tar.gz?download=1",
+        url="https://zenodo.org/record/10779221/files/Data.tar.gz?download=1",
         processor=Untar(),
-        known_hash="98b2bfadefa62dd223224c797354f9266b54143c2af3c4b6fe676d8547e7d5ee",
+        known_hash="md5:b0277b809840e08a84f3a5d2c3f7404b",
     )
     symlink_args = dict(
         src=f"{os.path.commonpath(fnames)}",

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -54,7 +54,7 @@ dependencies:
 - imageio
 - pre-commit
 - xmitgcm
-- intake = 0.7
+- intake
 - intake-xarray
 - pip:
   - black-nb


### PR DESCRIPTION
New attempt to remove pin for intake. This PR:

- [x] Addresses and therefore closes issue #415 . Intake no longer needs to be pinned
- [x] Updates the location of oceanspy's test data in zenodo, as specified on the `tests/conftest.py` file 
- [x] all tests pass on my local machine with an updated ospy_tests environment which include intake version 2.x

This PR makes #419 inconsequential and will be closing without merging. 

It took me some time over the weekend, but I found that my mac was making hidden copies of files when taring the Data folder. These hidden `._` files were causing errors when reading and openining the `xmitgcm_iters` and `xmitgcm_noiters` datasets. ugh... all should be good now.