### PR TITLE
compatibility with numpy>=2.0 and +

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - python
-- numpy>=2.0
+- numpy
 - matplotlib
 - pandas
 - bokeh

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - python
-- numpy
+- numpy>=2.0
 - matplotlib
 - pandas
 - bokeh
@@ -15,9 +15,10 @@ dependencies:
 - xoak
 - cartopy
 - esmpy
+- intake=0.7
 - intake-xarray
 - geopy
-- xesmf > 0.6.3
+- xesmf>0.6.3
 - esmf
 - xgcm
 - Ipython

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,11 +6,12 @@ dependencies:
 - distributed
 - bottleneck
 - netCDF4
+- numpy>=2.0
 - xarray
 - xoak
 - cartopy
 - scipy
-- intake
+- intake=0.7
 - intake-xarray
 - geopy
 - xesmf > 0.6.3

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -6,7 +6,7 @@ dependencies:
 - distributed
 - bottleneck
 - netCDF4
-- numpy>=2.0
+- numpy
 - xarray
 - xoak
 - cartopy

--- a/oceanspy/utils.py
+++ b/oceanspy/utils.py
@@ -520,7 +520,7 @@ def densjmd95(s, t, p):
         if isinstance(var, _xr.DataArray):
             var = var.astype("float")
         else:
-            var = _np.asfarray(var)
+            var = _np.asarray(var, _np.float64)
 
     # coefficients nonlinear equation of state in pressure coordinates for
     # 1. density of fresh water at p = 0
@@ -681,7 +681,7 @@ def densmdjwf(s, t, p):
         if isinstance(var, _xr.DataArray):
             var = var.astype("float")
         else:
-            var = _np.asfarray(var)
+            var = _np.asarray(var, _np.float64)
 
     # coefficients nonlinear equation of state in pressure coordinates for
     eosMDJWFnum = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering"
 ]
 dependencies = [
   "dask",
-  "xarray >= 0.14.1",
+  "xarray >= 2024.7.0",
   "xgcm >= 0.2.0",
   "shapely"
 ]
@@ -25,7 +25,7 @@ dynamic = ["version"]
 license = {file = "LICENSE"}
 name = "oceanspy"
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [tool.coverage.run]
 branch = true

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
 - python=3.11
 - dask
-- numpy>=2.0
+- numpy
 - distributed
 - bottleneck
 - netCDF4

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -2,8 +2,9 @@ name: Oceanography
 channels:
 - conda-forge
 dependencies:
-- python=3.10
+- python=3.11
 - dask
+- numpy>=2.0
 - distributed
 - bottleneck
 - netCDF4
@@ -12,7 +13,7 @@ dependencies:
 - cartopy
 - esmpy
 - geopy
-- xesmf > 0.6.3
+- xesmf>0.6.3
 - esmf
 - xgcm
 - Ipython
@@ -54,7 +55,7 @@ dependencies:
 - imageio
 - pre-commit
 - xmitgcm
-- intake
+- intake=0.7
 - intake-xarray
 - pip:
   - black-nb


### PR DESCRIPTION
This PR:

- [x] Closes #448 
- [x] Closes #449 by dropping Python 3.9 and including 3.12 from the testing.

