### PR TITLE
fix spacing in env.yaml to allow CI build

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - intake=0.7
 - intake-xarray
 - geopy
-- xesmf > 0.6.3
+- xesmf>0.6.3
 - esmf
 - xgcm
 - Ipython


### PR DESCRIPTION
This PR fixes the CI build errors with micromambav2 that fail to build the appropriate environment. The specific errors are:

```python
critical libmamba Error parsing MatchSpec "xesmf[version='>',build=0.6.3]": Error setting attribute "version" to value ">": Error parsing version "". Empty version."
```

The issue is that `micromamba2` cannot parse the empty space in the yml file next to the packages. And so it attempts to find a matching version == '>'. 