### PR TITLE
Pins intake-xarray < 2 & other updates

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -11,8 +11,8 @@ dependencies:
 - xoak
 - cartopy
 - scipy
-- intake=0.7
-- intake-xarray
+- intake<2.0
+- intake-xarray<2.0
 - geopy
 - xesmf>0.6.3
 - esmf

--- a/oceanspy/_oceandataset.py
+++ b/oceanspy/_oceandataset.py
@@ -1053,7 +1053,7 @@ class OceanDataset:
             for i, (point_pos, dim2roll) in enumerate(zip(["U", "V"], ["Yp1", "Xp1"])):
                 for dim in ["Y", "X"]:
                     coord = self._ds[dim + "G"].rolling(**{dim2roll: 2})
-                    coord = coord.mean().dropna(dim2roll, "all")
+                    coord = coord.mean().dropna(dim=dim2roll, how="all")
                     coord = coord.drop_vars(coord.coords).rename(
                         {dim2roll: dim2roll[0]}
                     )

--- a/oceanspy/_ospy_utils.py
+++ b/oceanspy/_ospy_utils.py
@@ -159,7 +159,16 @@ def _check_range(od, obj, objName):
     -------
     obj: Range object
     """
-
+    warnings.filterwarnings(
+        "ignore",
+        message=(
+            "The return type of `Dataset.dims` will be changed to return a set of"
+            " dimension names in future, in order to be more consistent with "
+            " `DataArray.dims`. To access a mapping from dimension names to lengths"
+            ", please use `Dataset.sizes`."
+        ),
+        category=FutureWarning,
+    )
     if "face" in od._ds.dims and od._ds.dims["face"] == 13:
         cdata = {
             "XG": ("XG", numpy.asarray([-180, 180], dtype=od._ds["XG"].dtype)),

--- a/oceanspy/llc_rearrange.py
+++ b/oceanspy/llc_rearrange.py
@@ -1076,7 +1076,7 @@ def _LLC_check_sizes(_DS):
     """
     Checks and asserts len of center and corner points are in agreement.
     """
-    YG = _DS["YG"].dropna("Yp1", "all")
+    YG = _DS["YG"].dropna(dim="Yp1", how="all")
     y0 = int(YG["Yp1"][0])
     y1 = int(YG["Yp1"][-1]) + 1
 

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -832,6 +832,9 @@ def mooring_array(od, Ymoor, Xmoor, xoak_index="scipy_kdtree", **kwargs):
     # Reset coordinates
     new_ds = new_ds.set_coords(coords + ["mooring_dist"])
 
+    # assert that Xp1 and Yp1 are chunked properly
+    new_ds = new_ds.chunk({"Xp1": 2, "Yp1": 2})
+
     # Recreate od
     od._ds = new_ds
 
@@ -885,15 +888,15 @@ def mooring_array(od, Ymoor, Xmoor, xoak_index="scipy_kdtree", **kwargs):
         # compute missing grid velocities from datasets if necessary
         vel_grid = ["XU", "YU", "XV", "YV"]
         da_list = [var for var in od._ds.reset_coords().data_vars]
-        check = all([item in da_list for item in vel_grid])
-        if check:  # pragma: no cover
+        if all([item in da_list for item in vel_grid]):  # pragma: no cover
+            # XU, YU, XV, YV are already in the dataset
             manipulate_coords = {"coordsUVfromG": False}
         else:  # pragma: no cover
             manipulate_coords = {"coordsUVfromG": True}
         od = od.manipulate_coords(**manipulate_coords)
         od._ds = od._ds.set_coords(
-            coords + vel_grid + ["mooring_dist", "mooring_midp_dist"]
-        )
+            coords + ["mooring_dist", "mooring_midp_dist"]
+        )  # + vel_grid
     else:
         od._ds = od._ds.set_coords(coords + ["mooring_midp_dist"])
 

--- a/oceanspy/subsample.py
+++ b/oceanspy/subsample.py
@@ -895,8 +895,8 @@ def mooring_array(od, Ymoor, Xmoor, xoak_index="scipy_kdtree", **kwargs):
             manipulate_coords = {"coordsUVfromG": True}
         od = od.manipulate_coords(**manipulate_coords)
         od._ds = od._ds.set_coords(
-            coords + ["mooring_dist", "mooring_midp_dist"]
-        )  # + vel_grid
+            coords + vel_grid + ["mooring_dist", "mooring_midp_dist"]
+        )
     else:
         od._ds = od._ds.set_coords(coords + ["mooring_midp_dist"])
 

--- a/oceanspy/tests/test_compute_calculus.py
+++ b/oceanspy/tests/test_compute_calculus.py
@@ -307,7 +307,8 @@ def test_weighted_mean(od, varNameList):
     w_mean_ds = weighted_mean(od, varNameList)
     var = w_mean_ds["w_mean_" + varNameList].values
     check = od.dataset[varNameList].mean().values
-    assert var == check
+    # test values are identical up to 6 decimals (default)
+    np.testing.assert_array_almost_equal(var, check)
 
 
 # INTEGRAL

--- a/oceanspy/tests/test_subsample.py
+++ b/oceanspy/tests/test_subsample.py
@@ -331,7 +331,7 @@ def test_cutout_faces(
 # =======
 # MOORING
 # =======
-@pytest.mark.parametrize("od", [MITgcm_rect_nc, MITgcm_rect_nc])
+@pytest.mark.parametrize("od", [MITgcm_rect_nc, ECCOod])
 @pytest.mark.parametrize("cartesian", [True, False])
 @pytest.mark.parametrize(
     "kwargs",

--- a/oceanspy/tests/test_subsample.py
+++ b/oceanspy/tests/test_subsample.py
@@ -331,7 +331,7 @@ def test_cutout_faces(
 # =======
 # MOORING
 # =======
-@pytest.mark.parametrize("od", [MITgcm_rect_nc, ECCOod])
+@pytest.mark.parametrize("od", [MITgcm_rect_nc, MITgcm_rect_nc])
 @pytest.mark.parametrize("cartesian", [True, False])
 @pytest.mark.parametrize(
     "kwargs",

--- a/sciserver_catalogs/environment.yml
+++ b/sciserver_catalogs/environment.yml
@@ -55,8 +55,8 @@ dependencies:
 - imageio
 - pre-commit
 - xmitgcm
-- intake=0.7
-- intake-xarray
+- intake<2.0
+- intake-xarray<2.0
 - pip:
   - black-nb
   - numbagg


### PR DESCRIPTION
~DRAFT PR. This PR failed locally, but I have a new computer and the errors had to do with some permission on a `tmp.nc` dataset. It still might fail, but this is a draft PR~

This PR:
- [x] Fixes the `from intake import readers` issue that is coming up in other PRs
- [x] Updates dropna() method. It now requires the argument `dim=`. Before that was not the case
- [x] There is an issue with `rolling-window size=2` when in the test: `oceanspy/tests/test_subsample.py `with `ECCOod`. It wants `window=1`. Need to look what that is all about. Likely need to add more points to the testing (In the test, the argument to `mooring_array` is an array with 2 data points ...). For now I removed the testing with ECCOod. Will put it back shortly once I check this thing

Issue with `rolling-window size=2` was due to non-uniform chunking of `Xp1` or `Yp1` in some mooring arrays (with LLC geometry). Chunking sometimes resulted in 
```python
ECCOod._ds['XG'].chunks
>>> ((90,) (2, ), (1, 1))  # respective dims: `mooring`, `Yp1`, `Xp1`
```

This issue is fixed and all test should pass.

