### PR TITLE
Separate pooch download from pytest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,56 @@ defaults:
   run:
     shell: bash -l {0}
 
+# Create a shared path for pooch cache and extracted data directory
+env:
+  POOCH_CACHE_DIR: ~/.cache/pooch
+  OCEANSPY_TEST_DATA_DIR: ~/.cache/pooch/oceanspy-test-data
+
 jobs:
+  # Primes data download outside of pytest (single job, no matrix)
+  prime-data:
+    name: Prime test data cache
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        environment-file: ci/environment.yml
+        environment-name: oceanspy_test
+        create-args: >-
+          python=3.12
+        cache-environment: true
+
+    # Restore/save pooch cache
+    - name: Restore Pooch cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pooch
+        key: pooch-zenodo-10779221-md5-b0277b809840e08a84f3a5d2c3f7404b
+
+    # Download + untar once
+    - name: Prime dataset (download + untar if missing)
+      run: |
+        python - <<'PY'
+        import os, pooch
+        from pooch import Untar
+
+        pooch.retrieve(
+            url="https://zenodo.org/record/10779221/files/Data.tar.gz?download=1",
+            known_hash="md5:b0277b809840e08a84f3a5d2c3f7404b",
+            path=os.environ["POOCH_CACHE_DIR"],
+            processor=Untar(extract_dir="oceanspy-test-data"),
+        )
+        print("Primed:", os.environ["OCEANSPY_TEST_DATA_DIR"])
+        PY
+
   pytest:
     name: Build (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Wait for priming to finish
+    needs: prime-data
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -39,6 +85,13 @@ jobs:
           python=${{ matrix.python-version }}
         cache-environment: true
 
+    # Restore pooch cache in each matrix job using the key defined above
+    - name: Restore Pooch cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pooch
+        key: pooch-zenodo-10779221-md5-b0277b809840e08a84f3a5d2c3f7404b
+
     - name: Set up conda environment
       run: |
         python -m pip install -e .
@@ -46,7 +99,7 @@ jobs:
         conda list
 
     - name: Run Tests
-      run: pytest -v --cov=./ --cov-report=xml
+      run: pytest -n 4 -v --cov=./ --cov-report=xml
 
     - name: Upload code coverage to Codecov
       uses: codecov/codecov-action@v5.5.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,8 @@ defaults:
 
 # Create a shared path for pooch cache and extracted data directory
 env:
-  POOCH_CACHE_DIR: ~/.cache/pooch
-  OCEANSPY_TEST_DATA_DIR: ~/.cache/pooch/oceanspy-test-data
+  POOCH_CACHE_DIR: ${{ github.workspace }}/.pooch_cache
+  OCEANSPY_TEST_DATA_DIR: ${{ github.workspace }}/.pooch_cache/oceanspy-test-data
 
 jobs:
   # Primes data download outside of pytest (single job, no matrix)
@@ -46,8 +46,16 @@ jobs:
     - name: Restore Pooch cache
       uses: actions/cache@v4
       with:
-        path: ~/.cache/pooch
+        path: ${{ github.workspace }}/.pooch_cache
         key: pooch-zenodo-10779221-md5-b0277b809840e08a84f3a5d2c3f7404b
+
+    - name: Test primed data presence
+      run: |
+        echo "POOCH_CACHE_DIR=$POOCH_CACHE_DIR"
+        echo "OCEANSPY_TEST_DATA_DIR=$OCEANSPY_TEST_DATA_DIR"
+        ls -la "$POOCH_CACHE_DIR" || true
+        ls -la "$OCEANSPY_TEST_DATA_DIR" || true
+
 
     # Download + untar once
     - name: Prime dataset (download + untar if missing)
@@ -89,7 +97,7 @@ jobs:
     - name: Restore Pooch cache
       uses: actions/cache@v4
       with:
-        path: ~/.cache/pooch
+        path: ${{ github.workspace }}/.pooch_cache
         key: pooch-zenodo-10779221-md5-b0277b809840e08a84f3a5d2c3f7404b
 
     - name: Set up conda environment

--- a/oceanspy/tests/conftest.py
+++ b/oceanspy/tests/conftest.py
@@ -1,25 +1,54 @@
-# Import modules
 import os
+import pathlib
 
 import pooch
 from pooch import Untar
 
+DATA_URL = "https://zenodo.org/record/10779221/files/Data.tar.gz?download=1"
+DATA_HASH = "md5:b0277b809840e08a84f3a5d2c3f7404b"
+EXTRACT_DIRNAME = "oceanspy-test-data"  # stable extracted folder name
 
-# Download data if necessary
-def pytest_configure():
+
+def _ensure_symlink(src: str, dst: str) -> None:
+    src_path = pathlib.Path(src).resolve()
+    dst_path = pathlib.Path(dst)
+
+    dst_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # If it's already the correct symlink, do nothing
+    if dst_path.is_symlink() and dst_path.resolve() == src_path:
+        return
+
+    if dst_path.exists() or dst_path.is_symlink():
+        dst_path.unlink()
+
+    os.symlink(str(src_path), str(dst_path), target_is_directory=True)
+
+
+def _get_data_dir() -> str:
+    # CI (or user override): use pre-primed directory
+    env_dir = os.environ.get("OCEANSPY_TEST_DATA_DIR")
+    if env_dir:
+        p = pathlib.Path(env_dir)
+        if not p.exists():
+            raise RuntimeError(f"OCEANSPY_TEST_DATA_DIR set but missing: {env_dir}")
+        return str(p.resolve())
+
+    # Local/dev: download+untar using pooch if needed (uses local cache)
+    cache_dir = os.environ.get("POOCH_CACHE_DIR", pooch.os_cache("oceanspy"))
     fnames = pooch.retrieve(
-        url="https://zenodo.org/record/10779221/files/Data.tar.gz?download=1",
-        processor=Untar(),
-        known_hash="md5:b0277b809840e08a84f3a5d2c3f7404b",
+        url=DATA_URL,
+        known_hash=DATA_HASH,
+        path=cache_dir,
+        processor=Untar(extract_dir=EXTRACT_DIRNAME),
     )
-    symlink_args = dict(
-        src=f"{os.path.commonpath(fnames)}",
-        dst="./oceanspy/tests/Data",
-        target_is_directory=True,
-    )
-    try:
-        print(f"Linking {symlink_args['src']!r} to {symlink_args['dst']!r}")
-        os.symlink(**symlink_args)
-    except FileExistsError:
-        os.unlink("./oceanspy/tests/Data")
-        os.symlink(**symlink_args)
+    return os.path.commonpath(fnames)
+
+
+def pytest_sessionstart(session):
+    # xdist workers should not do this
+    if os.environ.get("PYTEST_XDIST_WORKER"):
+        return
+
+    data_dir = _get_data_dir()
+    _ensure_symlink(data_dir, "./oceanspy/tests/Data")


### PR DESCRIPTION
It seems, based on some previous PR (see #481 ) that creating a PR creates too many HTTP requests that overwhelm zenodo. For example the current failures express the following HTTPError:

```
INTERNALERROR> requests.exceptions.HTTPError: 429 Client Error: Too Many Requests for url: https://zenodo.org/record/10779221/files/Data.tar.gz?download=1
```
The behavior may be exacerbated by adding parallelism (pytest-xdist) in the testing.

Pooch download is defined in the conftest file. And it seems that a pooch downdload is triggered for each python version defined in the ci-testing matrix (one per python 3.10,3.11, 3.12,etc), potentially overwhelming zenodo with HTTP requests.

This PR attempts to fix this by separating the Pooch download from the testing matrix by

- [x] Setting up a job in the `ci.yaml` that takes care of the download once, and creates a cache key/ cache dir that can be linked inside each pytest
- [x] modify conftest to recover the cache directory.
- [x] Preserve local behavior (backwards compat) when running pytest locally (downloads via pooch) 


